### PR TITLE
Every other row unreadable on Android Firefox

### DIFF
--- a/_layouts/default.html
+++ b/_layouts/default.html
@@ -8,7 +8,6 @@
         <meta http-equiv="X-UA-Compatible" content="IE=edge">
         <title>Ruby Code of Conduct</title>
         <meta name="description" content="">
-        <meta name="viewport" content="width=device-width, initial-scale=1">
 
         <!-- Place favicon.ico and apple-touch-icon.png in the root directory -->
         <link href='http://fonts.googleapis.com/css?family=Open+Sans:400,800' rel='stylesheet' type='text/css'>


### PR DESCRIPTION
Every other row of the table is unreadable on Android Firefox – before zooming out it looks like this:

![screenshot_2015-03-06-22-20-13](https://cloud.githubusercontent.com/assets/56633/6536634/a297d604-c44f-11e4-9b40-3570db0c633b.png)

and after zooming out it looks like this:

![screenshot_2015-03-06-22-20-18](https://cloud.githubusercontent.com/assets/56633/6536644/b6c8a978-c44f-11e4-983b-96e0b9d53462.png)

I have no clue how to _properly_ fix this, but a quick search suggested that dropping the viewport meta tag should solve the problem, and hey presto:

![screenshot_2015-03-06-22-20-24](https://cloud.githubusercontent.com/assets/56633/6536659/d2d89cea-c44f-11e4-916a-c7b9e1f0f2c0.png)

Also zooms in properly.
