### PR TITLE
Add ROSSConf Vienna

### DIFF
--- a/js/main.js
+++ b/js/main.js
@@ -195,6 +195,9 @@ Confs.data = [
   }, {
     name: "Ruby devroom at FOSDEM",
     policies: [{ text: "CoC", url: "http://rubyberlin.github.io/code-of-conduct/"}]
+  }, {
+    name: "ROSSConf Vienna",
+    policies: [{ text: "CoC", url: "http://www.rossconf.io/#coc"}]
   }
 ];
 Confs.find = function(conf) {


### PR DESCRIPTION
I hope to get https://github.com/ruby-conferences/ruby-conferences-site/pull/77 merged, and it’d be nice if ROSSConf Vienna showed up here as well then. :)
